### PR TITLE
feat(design-system): replace all greenish colors with aqua blue for b…

### DIFF
--- a/frontend/src/components/AddFriendModal.tsx
+++ b/frontend/src/components/AddFriendModal.tsx
@@ -113,7 +113,7 @@ const AddFriendModal: React.FC<AddFriendModalProps> = ({ isOpen, onClose }): JSX
               </div>
               
               {successMessage && (
-                <div className="bg-green-50 border border-green-200 text-green-800 px-4 py-3 rounded-lg text-sm">
+                <div className="bg-aqua/10 border border-aqua/30 text-aqua px-4 py-3 rounded-lg text-sm">
                   {successMessage}
                 </div>
               )}
@@ -152,7 +152,7 @@ const AddFriendModal: React.FC<AddFriendModalProps> = ({ isOpen, onClose }): JSX
                 </p>
                 
                 {successMessage ? (
-                  <div className="bg-green-50 border border-green-200 text-green-800 px-4 py-3 rounded-lg text-sm mb-4">
+                  <div className="bg-aqua/10 border border-aqua/30 text-aqua px-4 py-3 rounded-lg text-sm mb-4">
                     {successMessage}
                   </div>
                 ) : null}

--- a/frontend/src/components/ConversationModal.tsx
+++ b/frontend/src/components/ConversationModal.tsx
@@ -548,7 +548,7 @@ const ConversationModal: React.FC<ConversationModalProps> = ({
                           <div className="flex gap-2 mt-3">
                             <button
                               onClick={() => handlePermissionResponse(msg.id, true, msg.permissionData!.queuedMessageId!)}
-                              className="flex items-center gap-1 px-3 py-2 bg-green-500 hover:bg-green-600 text-white text-xs font-medium rounded-full transition-colors hover-scale"
+                              className="flex items-center gap-1 px-3 py-2 bg-aqua hover:bg-aqua-dark text-white text-xs font-medium rounded-full transition-colors hover-scale"
                             >
                               <Check size={12} />
                               Yes
@@ -566,7 +566,7 @@ const ConversationModal: React.FC<ConversationModalProps> = ({
                           <div className="mt-2">
                             <span className={`px-2 py-1 text-xs font-medium rounded-full ${
                               msg.permissionData.isApproved 
-                                ? 'bg-green-100 text-green-700' 
+                                ? 'bg-aqua/20 text-aqua' 
                                 : 'bg-red-100 text-red-700'
                             }`}>
                               {msg.permissionData.isApproved ? '✓ Accepted' : '✗ Declined'}

--- a/frontend/src/components/FriendButton.tsx
+++ b/frontend/src/components/FriendButton.tsx
@@ -84,8 +84,8 @@ const FriendButton: React.FC<FriendButtonProps> = ({
       
       case 'pending_received':
         return variant === 'outline'
-          ? 'border-green-500 text-green-600 hover:bg-green-50'
-          : 'bg-green-500 text-white hover:bg-green-600';
+          ? 'border-aqua text-aqua hover:bg-aqua/10'
+          : 'bg-aqua text-white hover:bg-aqua-dark';
       
       case 'none':
       default:
@@ -181,7 +181,7 @@ export const FriendButtonMini: React.FC<FriendButtonMiniProps> = ({
       case 'pending_sent':
         return 'bg-gray-400 cursor-not-allowed';
       case 'pending_received':
-        return 'bg-green-500 hover:bg-green-600';
+        return 'bg-aqua hover:bg-aqua-dark';
       case 'none':
       default:
         return 'bg-aqua hover:bg-aqua/90';

--- a/frontend/src/design-system.md
+++ b/frontend/src/design-system.md
@@ -29,7 +29,7 @@ aqua-deeper: #0f766e   /* Maps to primary-700 */
 
 ### Semantic Colors (For States)
 ```css
-semantic-success: #22c55e  /* Green for success states */
+semantic-success: #14b8a6  /* Aqua for success states (brand consistent) */
 semantic-warning: #f59e0b  /* Amber for warnings */
 semantic-danger:  #ef4444  /* Red for errors/danger */
 semantic-info:    #3b82f6  /* Blue for info states */
@@ -81,7 +81,7 @@ accent-pink:         #ec4899  /* Pink accent */
 - Consistent padding and border radius
 
 ### Status Indicators
-- **`.online-indicator`** - Aqua availability indicator (was green, changed for palette consistency)
+- **`.online-indicator`** - Aqua availability indicator (consistent with brand palette)
 - **`.offline-indicator`** - Copper busy/offline indicator
 
 ## 🎭 Animations & Effects

--- a/frontend/src/docs/design-system-audit-summary.md
+++ b/frontend/src/docs/design-system-audit-summary.md
@@ -44,7 +44,7 @@ aqua: #06b6d4 vs #0e7490 vs #2dd4bf
 ```css
 /* Unified system */
 aqua: #14b8a6           /* Maps to primary-500 */
-semantic-success: #22c55e  /* Green for success */
+semantic-success: #14b8a6  /* Aqua for success (brand consistent) */
 semantic-danger: #ef4444   /* Red for errors */
 surface-primary: #ffffff   /* Consistent naming */
 ```

--- a/frontend/src/examples/AuthExample.tsx
+++ b/frontend/src/examples/AuthExample.tsx
@@ -227,7 +227,7 @@ export function AuthExample(): JSX.Element {
               <button
                 type="submit"
                 disabled={isLoading}
-                className="w-full px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600 disabled:opacity-50"
+                className="w-full px-4 py-2 bg-aqua text-white rounded hover:bg-aqua-dark disabled:opacity-50"
               >
                 {isLoading ? 'Registering...' : 'Register'}
               </button>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -68,7 +68,7 @@
 
   /* Status indicators with accessibility improvements */
   .online-indicator {
-    @apply w-3 h-3 bg-semantic-success rounded-full border-2 border-white absolute bottom-0.5 right-0.5;
+    @apply w-3 h-3 bg-aqua rounded-full border-2 border-white absolute bottom-0.5 right-0.5;
   }
 
   .offline-indicator {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -29,7 +29,7 @@ module.exports = {
         },
         // Semantic color system
         semantic: {
-          success: '#22c55e',    // Green for success states
+          success: '#14b8a6',    // Aqua for success states (consistent with brand)
           warning: '#f59e0b',    // Amber for warnings  
           danger: '#ef4444',     // Red for errors/danger
           info: '#3b82f6',       // Blue for info states


### PR DESCRIPTION
…rand consistency

- Updated online-indicator from semantic-success green to aqua
- Replaced green approval buttons in ConversationModal with aqua
- Changed success messages in AddFriendModal to aqua styling
- Fixed FriendButton pending_received state to use aqua instead of green
- Updated semantic-success color from #22c55e to #14b8a6 in Tailwind config
- Updated design-system.md documentation to reflect aqua consistency
- Fixed AuthExample register button to use aqua
- Updated design system audit documentation

All UI elements now consistently use the aqua brand color (#14b8a6) instead of various green hues, creating a unified visual experience that strengthens brand identity and improves design coherence.